### PR TITLE
Fixes spelling from 'warp up' to 'wrap up'.

### DIFF
--- a/Universal/awac-methods/manual.md
+++ b/Universal/awac-methods/manual.md
@@ -110,6 +110,6 @@ Scope (_SB.PCI0.LPC) <- Renamed
 
 ## Wrapping up
 
-Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to warp up:
+Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to wrap up:
 
 * [**Cleanup**](/cleanup.md)

--- a/Universal/awac-methods/prebuilt.md
+++ b/Universal/awac-methods/prebuilt.md
@@ -12,6 +12,6 @@ Main things to note with this method:
 
 ## Wrapping up
 
-Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to warp up:
+Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to wrap up:
 
 * [**Cleanup**](/cleanup.md)

--- a/Universal/ec-methods/manual.md
+++ b/Universal/ec-methods/manual.md
@@ -150,6 +150,6 @@ Example of an EC with STA already:
 
 ## Wrapping up
 
-Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to warp up:
+Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to wrap up:
 
 * [**Cleanup**](/cleanup.md)

--- a/Universal/ec-methods/prebuilt.md
+++ b/Universal/ec-methods/prebuilt.md
@@ -25,6 +25,6 @@ The main things to note with this method:
 
 ## Wrapping up
 
-Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to warp up:
+Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to wrap up:
 
 * [**Cleanup**](/cleanup.md)

--- a/Universal/ec-methods/ssdttime.md
+++ b/Universal/ec-methods/ssdttime.md
@@ -22,6 +22,6 @@ The main things to note with this method:
 
 ## Wrapping up
 
-Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to warp up:
+Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to wrap up:
 
 * [**Cleanup**](/cleanup.md)

--- a/Universal/rhub-methods/prebuilt.md
+++ b/Universal/rhub-methods/prebuilt.md
@@ -6,6 +6,6 @@ By far the easiest method, all you need to do is download the following file:
 
 ## Wrapping up
 
-Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to warp up:
+Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to wrap up:
 
 * [**Cleanup**](/cleanup.md)

--- a/Universal/smbus-methods/manual.md
+++ b/Universal/smbus-methods/manual.md
@@ -96,7 +96,7 @@ Device (_SB.PC00.SMBS.BUS0) <- Renamed
 
 # Wrapping up
 
-Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to warp up:
+Once you're done making your SSDT, either head to the next page to finish the rest of the SSDTs or head here if you're ready to wrap up:
 
 * [**Cleanup**](/cleanup.md)
 


### PR DESCRIPTION
In 'Wrapping up' section accross the files spelling is corrected from 'warp up' to 'wrap up'. I relied on github search and I hope all the instances of this error are covered this time. 