### PR TITLE
10th gen motherboards do not need SSDT-PMC

### DIFF
--- a/ssdt-platform.md
+++ b/ssdt-platform.md
@@ -18,8 +18,8 @@ Please see the **specific ACPI section of your config.plist**, all SSDTs needed 
 | Skylake | ^^ | [SSDT-EC-USBX](/Universal/ec-fix.html) | ^^ | ^^ | ^^ |
 | Kaby Lake | ^^ | ^^ | ^^ | ^^ | ^^ |
 | Coffee Lake | ^^ | ^^ | [SSDT-AWAC](/Universal/awac.html) | [SSDT-PMC](/Universal/nvram.html) | ^^ |
-| Comet Lake | ^^ | ^^ | ^^ | ^^ | [SSDT-RHUB](/Universal/rhub.html) |
-| AMD (15/16/17h) | N/A | ^^ | N/A | N/A | N/A |
+| Comet Lake | ^^ | ^^ | ^^ | N/A | [SSDT-RHUB](/Universal/rhub.html) |
+| AMD (15/16/17h) | N/A | ^^ | N/A | ^^ | N/A |
 
 ## High End Desktop
 


### PR DESCRIPTION
Two tables in [OpenCore Install Guide](https://dortania.github.io/OpenCore-Install-Guide/ktext.html#desktop) and [Getting Started With ACPI](https://dortania.github.io/Getting-Started-With-ACPI/ssdt-platform.html#desktop) are different. According to [NVRAM PMC](https://dortania.github.io/Getting-Started-With-ACPI/Universal/nvram.html), the former one is correct.