### PR TITLE
Fixing typo in fixing backlight (prebuilt)

### DIFF
--- a/Laptops/backlight-methods/prebuilt.md
+++ b/Laptops/backlight-methods/prebuilt.md
@@ -9,6 +9,6 @@ By far the easiest method, all you need to do is download the following file:
 
 Main things to note with this method:
 
-* Assumes GPU pathing, works great for 99% of devices but if you're having issues controlling backlight this may be something to look at
+* Assumes GPU patching, works great for 99% of devices but if you're having issues controlling backlight this may be something to look at
 * Doesn't really teach you anything
   * For most, this doesn't matter. But to some knowing what makes your hackintosh tick is part of the journey


### PR DESCRIPTION
It says "GPU pathing", however it sounds like it actually meant "GPU patching".