### PR TITLE
Update manual.md

### DIFF
--- a/Laptops/backlight-methods/manual.md
+++ b/Laptops/backlight-methods/manual.md
@@ -12,7 +12,7 @@ Unfortunately there is no guidance for this yet. Try on Linux or Windows.
 
 ### On Linux
 These steps work on Ubuntu and may work on other distros. If not then try the procedure for Windows.  
-Use the `lspci` command to get your display adapters 16-bit PCI domain number.  
+Use the `lspci` command to get your display adapters PCI identification number.  
 The output here will be different on your system!
 ```
 # lspci -D
@@ -23,10 +23,10 @@ The output here will be different on your system!
 0000:00:03.0 Ethernet controller: Intel Corporation 82540EM Gigabit Ethernet Controller (rev 02)
 0000:00:04.0 System peripheral: InnoTek Systemberatung GmbH VirtualBox Guest Service
 ```
-Search the output for an entry that looks like your display adapter. E.g: In this example we have `VGA compatible controller` with domain number `0000:00:02.0`. A portion of that number `0000:00` is the PCI bus number.  
+Search the output for an entry that looks like your display adapter. E.g: In this example we have `VGA compatible controller` with PCI number `0000:00:02.0`. The format of this number is `domain:bus:device:function`.  
 
 Now use this command from a Terminal to find the ACPI path for your display adapter  
-`# cat /sys/class/pci_bus/<bus number>/device/<domain number>/firmware_node/path`  
+`# cat /sys/class/pci_bus/<domain:bus>/device/<domain:bus:device:function>/firmware_node/path`  
 
 For example
 ```

--- a/Laptops/backlight-methods/manual.md
+++ b/Laptops/backlight-methods/manual.md
@@ -7,9 +7,37 @@
 
 ## Finding the ACPI path
 
-For this guide, we're gonna assume Windows is already on this laptop, as otherwise creating this SSDT is a bit more difficult.
+### On MacOS
+Unfortunately there is no guidance for this yet. Try on Linux or Windows.
 
-Now open DeviceManager, and head to the following:
+### On Linux
+These steps work on Ubuntu and may work on other distros. If not then try the procedure for Windows.  
+Use the `lspci` command to get your display adapters 16-bit PCI domain number.  
+The output here will be different on your system!
+```
+# lspci -D
+0000:00:00.0 Host bridge: Intel Corporation 440FX - 82441FX PMC [Natoma] (rev 02)
+0000:00:01.0 ISA bridge: Intel Corporation 82371SB PIIX3 ISA [Natoma/Triton II]
+0000:00:01.1 IDE interface: Intel Corporation 82371AB/EB/MB PIIX4 IDE (rev 01)
+0000:00:02.0 VGA compatible controller: VMware SVGA II Adapter
+0000:00:03.0 Ethernet controller: Intel Corporation 82540EM Gigabit Ethernet Controller (rev 02)
+0000:00:04.0 System peripheral: InnoTek Systemberatung GmbH VirtualBox Guest Service
+```
+Search the output for an entry that looks like your display adapter. E.g: In this example we have `VGA compatible controller` with domain number `0000:00:02.0`. A portion of that number `0000:00` is the PCI bus number.  
+
+Now use this command from a Terminal to find the ACPI path for your display adapter  
+`# cat /sys/class/pci_bus/<bus number>/device/<domain number>/firmware_node/path`  
+
+For example
+```
+# cat /sys/class/pci_bus/0000:00/device/0000:00:02.0/firmware_node/path
+\_SB_.PCI0.GFX0  <-- The ACPI path
+```
+Further details [at this link.](https://unix.stackexchange.com/questions/653143/how-to-get-bios-device-name-from-linux-same-as-windows-device-manager-format)
+
+### On Windows
+
+Open DeviceManager, and head to the following:
 
 ```
 Device Manager -> Display Adapters -> Properties -> Details > BIOS device name


### PR DESCRIPTION
Added a section to allow Linux users find the ACPI path for their display adapter.

Note sure if you want to include the link to the unix.stackexchange thread I made about this or not?

Would be great if we could put some MacOS guidance in there too?