### PR TITLE
Remove redundant links in edge case list

### DIFF
--- a/Universal/ec-methods/manual.md
+++ b/Universal/ec-methods/manual.md
@@ -43,18 +43,10 @@ But now we get into edge case territory, what fun!
 
 The main ones to check for are:
 
-* [Fixing Embedded Controllers: Manual](#fixing-embedded-controllers-manual)
-  * [Finding the ACPI path](#finding-the-acpi-path)
-    * [DSDT](#dsdt)
-    * [DeviceManager](#devicemanager)
-  * [Edits to the sample SSDT](#edits-to-the-sample-ssdt)
-  * [Edge Cases](#edge-cases)
-    * [Multiple PNP0C09's show up](#multiple-pnp0c09s-show-up)
-    * [No PNP0C09 show up](#no-pnp0c09-show-up)
-    * [PNP0C09 already named `EC`](#pnp0c09-already-named-ec)
-    * [PNP0C09 already has an `_STA` method](#pnp0c09-already-has-an-_sta-method)
-  * [Compiling the SSDT](#compiling-the-ssdt)
-  * [Wrapping up](#wrapping-up)
+* [Multiple PNP0C09's show up](#multiple-pnp0c09s-show-up)
+* [No PNP0C09 show up](#no-pnp0c09-show-up)
+* [PNP0C09 already named `EC`](#pnp0c09-already-named-ec)
+* [PNP0C09 already has an `_STA` method](#pnp0c09-already-has-an-_sta-method)
 
 If none of the above apply to you, you're ready for the next section:
 


### PR DESCRIPTION
The edge case list in the DSDT sections contains redundant links (basically a TOC of the file). Those links are now removed.