### PR TITLE
Fix Typo in ssdt-long.md

### DIFF
--- a/ssdt-methods/ssdt-long.md
+++ b/ssdt-methods/ssdt-long.md
@@ -2,7 +2,7 @@
 
 Well sadly some things are not handled by SSDTTime, well have no fear as making SSDTs is super easy. The basic process:
 
-* Dump DSDT(the one SSDTTime did for use will work)
+* Dump DSDT(the one SSDTTime did for us will work)
 * Decompile DSDT
 * Make SSDTs based off of it(You'll need either MaciASL or a text editor for this)
 * Compile SSDTs


### PR DESCRIPTION
I suppose the sentence 'the one SSDTTime did for *us* will work' sounds more appropriate than 
'the one SSDTTime did for *use* will work'.

- Proposal: Rename the word 'use' to 'us' on line 5. 
- Replaced line 5 'use' to 'us'.