### PR TITLE
Update SSDT-UNC0 to SSDT-UNC and their links

### DIFF
--- a/ssdt-methods/ssdt-prebuilt.md
+++ b/ssdt-methods/ssdt-prebuilt.md
@@ -529,7 +529,7 @@ SSDT-EC:
 ::: tip SSDTs required
 
 * [SSDT-EC-DESKTOP](https://github.com/dortania/Getting-Started-With-ACPI/blob/master/extra-files/compiled/SSDT-EC-DESKTOP.aml)
-* [SSDT-UNC0](https://github.com/dortania/Getting-Started-With-ACPI/blob/master/extra-files/compiled/SSDT-UNC0.aml)
+* [SSDT-UNC](https://github.com/dortania/Getting-Started-With-ACPI/blob/master/extra-files/compiled/SSDT-UNC.aml)
 
 Once downloaded, place them into your EFI folder under EFI/OC/ACPI and head back to the install guide
 
@@ -556,7 +556,7 @@ SSDT-UNC0:
 * [SSDT-PLUG-DRTNIA](https://github.com/dortania/Getting-Started-With-ACPI/blob/master/extra-files/compiled/SSDT-PLUG-DRTNIA.aml)
 * [SSDT-EC-USBX-DESKTOP](https://github.com/dortania/Getting-Started-With-ACPI/blob/master/extra-files/compiled/SSDT-EC-USBX-DESKTOP.aml)
 * [SSDT-RTC0-RANGE-HEDT](https://github.com/dortania/Getting-Started-With-ACPI/blob/master/extra-files/compiled/SSDT-RTC0-RANGE-HEDT.aml)
-* [SSDT-UNC0](https://github.com/dortania/Getting-Started-With-ACPI/blob/master/extra-files/compiled/SSDT-UNC0.aml)
+* [SSDT-UNC](https://github.com/dortania/Getting-Started-With-ACPI/blob/master/extra-files/compiled/SSDT-UNC.aml)
 
 Once downloaded, place them into your EFI folder under EFI/OC/ACPI and head back to the install guide
 


### PR DESCRIPTION
Update SSDT-UNC0 to SSDT-UNC and their links since they return 404 error with the original SSDT-UNC0 links do not exist anymore.

@dhinakg 